### PR TITLE
fix: only "upcoming" versions could be selected as issue related info

### DIFF
--- a/internal/service/release_version.go
+++ b/internal/service/release_version.go
@@ -9,7 +9,7 @@ import (
 	"tirelease/internal/entity"
 	"tirelease/internal/repository"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
对issue关联的版本号过滤前后对比
- <img width="945" alt="image" src="https://user-images.githubusercontent.com/11363886/166889881-726d6712-3510-4fdf-b9d3-766cd24814c0.png">
- 数据库中的upcoming的version信息
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/11363886/166889983-ab87b6b1-bf82-46b9-86e9-08d20ec06117.png">
-  对应接口返回数据
<img width="502" alt="image" src="https://user-images.githubusercontent.com/11363886/166890273-1562f656-ce49-4312-bd00-1003c038ddda.png">

