### PR TITLE
fix: 将原本逻辑修改为，仅当访问issue视角的api时过滤upcoming版本

### DIFF
--- a/internal/controller/issue_relation_info.go
+++ b/internal/controller/issue_relation_info.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"tirelease/internal/dto"
+	"tirelease/internal/entity"
 	"tirelease/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -24,6 +25,7 @@ func SelectIssueRelationInfos(c *gin.Context) {
 		option.PerPage = 10
 	}
 	option.ParamFill()
+	option.VersionStatus = entity.ReleaseVersionStatusUpcoming
 
 	// Action
 	issueRelationInfos, response, err := service.SelectIssueRelationInfo(&option)

--- a/internal/dto/issue_relation_info.go
+++ b/internal/dto/issue_relation_info.go
@@ -16,9 +16,10 @@ type IssueRelationInfoQuery struct {
 	ClosedAtStamp  int64 `json:"closed_at_stamp" form:"closed_at_stamp"`
 
 	// Filter Option
-	AffectVersion string                    `json:"affect_version,omitempty" form:"affect_version" uri:"affect_version"`
-	AffectResult  entity.AffectResultResult `json:"affect_result,omitempty" form:"affect_result" uri:"affect_result"`
-	BaseBranch    string                    `json:"base_branch,omitempty" form:"base_branch" uri:"base_branch"`
+	AffectVersion string                      `json:"affect_version,omitempty" form:"affect_version" uri:"affect_version"`
+	AffectResult  entity.AffectResultResult   `json:"affect_result,omitempty" form:"affect_result" uri:"affect_result"`
+	BaseBranch    string                      `json:"base_branch,omitempty" form:"base_branch" uri:"base_branch"`
+	VersionStatus entity.ReleaseVersionStatus `json:"version_status,omitempty" form:"version_status" uri:"version_status"`
 }
 
 // IssueRelationInfo ReturnBack Struct

--- a/internal/service/issue_relation_info_local.go
+++ b/internal/service/issue_relation_info_local.go
@@ -109,7 +109,7 @@ func SelectIssueRelationInfo(option *dto.IssueRelationInfoQuery) (*[]dto.IssueRe
 			IssueIDs: issueIDs,
 		}
 		versionTriageAlls, err := repository.SelectVersionTriage(versionTriageOption)
-		if nil == err {
+		if nil == err && option.VersionStatus == entity.ReleaseVersionStatusUpcoming {
 			versionTriageAlls, err = pickUpcomingTriages(versionTriageAlls)
 		}
 		if nil != err {


### PR DESCRIPTION
1. 在entity的issue_relation_info中添加VersionStatus字段用于过滤状态
2. 在contoller层添加判断，option.VersionStatus = xxxupcoming
3. service层添加条件当访问/issue路径时，仅选择upcoming的版本信息
4. 本地在/issue/all及/home/triage/5.4.1 两个页面验证通过