### PR TITLE
fix wrong value of 'Triage Status'

### DIFF
--- a/internal/service/version_triage_info.go
+++ b/internal/service/version_triage_info.go
@@ -242,6 +242,13 @@ func ComposeVersionTriageMergeStatus(issueRelationInfo *dto.IssueRelationInfo) e
 			closeNums++
 			continue
 		}
+
+		//TODO: 当前存在approve成功hook到git，但是数据库中状态不一致的问题
+		// 这里先兼容该情况，认为merge后的pr都是已approve过的，待重新设计状态机后修改逻辑
+		if pr.Merged {
+			continue
+		}
+
 		if !pr.CherryPickApproved {
 			return entity.VersionTriageMergeStatusApprove
 		} else if !pr.AlreadyReviewed {


### PR DESCRIPTION
to #90 
原因是当前数据库内存在脏数据 , ref: [tmp\_path is required if user deploy tiflash instance other than tiup/tidb\-operator by JaySon\-Huang · Pull Request \#7680 · pingcap/docs](https://github.com/pingcap/docs/pull/7680)
- pr里显示已经打上了cherry-pick-approved的标签
- 本地数据库内对应状态仍是未打该标签

由于不清楚这个脏数据是个例还是由代码逻辑造成的，因此这里先统一进行状态压制处理: 当pr已经merged的时候，不再对齐approved状态进行校验