### PR TITLE
Fix inequality between pick_to filter and pick_to value

### DIFF
--- a/website/src/components/issues/renderer/PickSelect.js
+++ b/website/src/components/issues/renderer/PickSelect.js
@@ -5,13 +5,14 @@ import Select from "@mui/material/Select";
 import { useMutation } from "react-query";
 import axios from "axios";
 import { url } from "../../../utils";
+import { mapPickStatusToBackend } from "./mapper"
 
 export default function PickSelect({
   id,
   version = "master",
   patch = "master",
   pick = "unknown",
-  onChange = () => {},
+  onChange = () => { },
 }) {
   const mutation = useMutation((newAffect) => {
     return axios.patch(url(`issue/${id}/cherrypick/${version}`), newAffect);
@@ -22,12 +23,7 @@ export default function PickSelect({
     mutation.mutate({
       issue_id: id,
       version_name: version,
-      triage_result: {
-        unknown: "UnKnown",
-        accept: "Accept",
-        later: "Later",
-        "won't fix": "Won't Fix",
-      }[event.target.value],
+      triage_result: mapPickStatusToBackend(event.target.value)
     });
     onChange(event.target.value);
     setAffects(event.target.value);
@@ -52,14 +48,14 @@ export default function PickSelect({
             >
               <MenuItem value={"N/A"} disabled={true}>-</MenuItem>
               <MenuItem value={"unknown"}>unknown</MenuItem>
-              <MenuItem value={"accept"}>
+              <MenuItem value={"approved"}>
                 <div style={{ color: "green", fontWeight: "bold" }}>
                   approved
                 </div>
               </MenuItem>
               <MenuItem value={"later"}>later</MenuItem>
               <MenuItem value={"won't fix"}>won't fix</MenuItem>
-              <MenuItem value={"accept(frozen)"} disabled={true}>approved (frozen)</MenuItem>
+              <MenuItem value={"approved(frozen)"} disabled={true}>approved(frozen)</MenuItem>
               <MenuItem value={"released"} disabled={true}>
                 released in {patch}
               </MenuItem>

--- a/website/src/components/issues/renderer/PickTriage.js
+++ b/website/src/components/issues/renderer/PickTriage.js
@@ -1,5 +1,6 @@
 import PickSelect from "./PickSelect";
 import { getAffection } from "./Affection";
+import { mapPickStatusToFrontend } from "./mapper"
 
 export function getPickTriageValue(version) {
   return (params) => {
@@ -13,7 +14,7 @@ export function getPickTriageValue(version) {
     if (version_triage === undefined) {
       return "N/A"
     }
-    return version_triage.triage_result?.toLocaleLowerCase();
+    return mapPickStatusToFrontend(version_triage.triage_result);
   };
 }
 
@@ -27,7 +28,7 @@ export function renderPickTriage(version) {
     let version_triage = params.row.version_triages?.filter((t) =>
       t.version_name.startsWith(version)
     )[0];
-    const pick = version_triage === undefined ? "N/A" : version_triage.triage_result?.toLocaleLowerCase();
+    const pick = version_triage === undefined ? "N/A" : mapPickStatusToFrontend(version_triage.triage_result);
     const patch = version_triage === undefined ? "N/A" : version_triage.version_name;
 
     return (

--- a/website/src/components/issues/renderer/mapper.js
+++ b/website/src/components/issues/renderer/mapper.js
@@ -1,0 +1,21 @@
+export function mapPickStatusToBackend(pick) {
+    return {
+        unknown: "UnKnown",
+        approved: "Accept",
+        later: "Later",
+        "won't fix": "Won't Fix",
+        "approve(frozen)": "Accept(Frozen)"
+    }[pick]
+}
+
+export function mapPickStatusToFrontend(pick) {
+    pick = pick.toLocaleLowerCase();
+    pick = {
+        accept: "approved",
+        unknown: "unknown",
+        later: "later",
+        "won't fix": "won't fix",
+        "accept(frozen)": "approved(frozen)"
+    }[pick]
+    return pick
+}


### PR DESCRIPTION
to #92 

原因是前端为了适配前后端**字符串不一致**进行了转换，导致select组件的value和实际展示值不一致。
Data Grid的Filter默认根据value进行筛选，导致搜索条件与展示值不一致

添加了mapper输出两个函数，收口该字段的映射逻辑并对使用到的地方进行替换