### PR TITLE
Optimize All Issue Plane: Add Issue created time and closed time and related filters.

### DIFF
--- a/internal/controller/issue_relation_info.go
+++ b/internal/controller/issue_relation_info.go
@@ -14,6 +14,7 @@ import (
 func SelectIssueRelationInfos(c *gin.Context) {
 	// Params
 	option := dto.IssueRelationInfoQuery{}
+
 	if err := c.ShouldBindWith(&option, binding.Form); err != nil {
 		c.Error(err)
 		return

--- a/internal/dto/issue_relation_info.go
+++ b/internal/dto/issue_relation_info.go
@@ -2,7 +2,6 @@ package dto
 
 import (
 	"time"
-
 	"tirelease/internal/entity"
 )
 

--- a/website/src/components/issues/GridColumns.js
+++ b/website/src/components/issues/GridColumns.js
@@ -8,6 +8,7 @@ import { Button, Dialog, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { renderComment } from "./renderer/Comment";
 import { renderChanged } from "./renderer/ChangedItem";
+import { renderDateTime } from './renderer/Time'
 
 const id = {
   field: "id",
@@ -83,6 +84,26 @@ const state = {
   headerName: "State",
   valueGetter: (params) => params.row.issue.state,
   renderCell: renderIssueState,
+};
+
+const createdTime = {
+  field: "create_time",
+  headerName: "Create Time",
+  hide: true,
+  valueGetter: (params) => params.row.issue.create_time,
+  renderCell: (params) => {
+    return renderDateTime(params.row.issue.create_time);
+  },
+};
+
+const closedTime = {
+  field: "close_time",
+  headerName: "Close Time",
+  hide: true,
+  valueGetter: (params) => params.row.issue.close_time,
+  renderCell: (params) => {
+    return renderDateTime(params.row.issue.close_time);
+  },
 };
 
 const assignee = {
@@ -176,6 +197,8 @@ const Columns = {
   number,
   title,
   state,
+  createdTime,
+  closedTime,
   type,
   labels,
   assignee,

--- a/website/src/components/issues/filter/FilterDialog.js
+++ b/website/src/components/issues/filter/FilterDialog.js
@@ -10,6 +10,9 @@ import Select from "@mui/material/Select";
 import FormGroup from "@mui/material/FormGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import { fetchVersion } from "../fetcher/fetchVersion";
+import DateTimePicker from "@mui/lab/DateTimePicker";
+import AdapterDateFns from "@mui/lab/AdapterDateFns";
+import LocalizationProvider from "@mui/lab/LocalizationProvider";
 
 export const stringify = (filter) =>
   (filter.stringify || ((filter) => filter))(filter);
@@ -272,7 +275,52 @@ const affect = {
   },
 };
 
-export const Filters = { number, repo, title, affect, type, state, severity };
+const createTime = {
+  name: "Create Time",
+  data: {
+    createTime:  null,
+  },
+  stringify: (self) => {
+    return self.data.createTime ? `created_at_stamp=${self.data.createTime.getTime()/1000}` : "";
+  },
+  render: ({ data, update }) => {
+    return (
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DateTimePicker
+          renderInput={(props) => <TextField {...props} />}
+          label="from"
+          value={data.createTime}
+          onChange={(e) => update({ createTime: e })}
+        />
+      </LocalizationProvider>
+    );
+  },
+};
+
+const closeTime = {
+  name: "Close Time",
+  data: {
+    closeTime: null,
+  },
+  stringify: (self) => {
+    return self.data.closeTime ? `closed_at_stamp=${self.data.closeTime.getTime()/1000}` : "";
+  },
+  render: ({ data, update }) => {
+    return (
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DateTimePicker
+          renderInput={(props) => <TextField {...props} />}
+          label="from"
+          value={data.closeTime}
+          onChange={(e) => update({ closeTime: e })}
+        />
+      </LocalizationProvider>
+    );
+  },
+};
+
+
+export const Filters = { number, repo, title, affect, type, state, severity, createTime, closeTime };
 
 export function FilterDialog({ open, onClose, onUpdate, filters }) {
   const [filterState, setFilterState] = React.useState(

--- a/website/src/components/issues/renderer/Time.js
+++ b/website/src/components/issues/renderer/Time.js
@@ -1,0 +1,15 @@
+import dayjs from "dayjs";
+
+export function renderDateTime(time) {
+    return (
+      <>
+        {time !== undefined && (
+          <div>
+            {dayjs(time).format(
+              "YYYY-MM-DD HH:mm:ss"
+            )}
+          </div>
+        )}
+      </>
+    );
+}

--- a/website/src/pages/all.js
+++ b/website/src/pages/all.js
@@ -85,6 +85,19 @@ function Table() {
             versions: versionQuery.data,
           },
         },
+        {
+          ...Filters.createTime,
+          data: {
+            ...JSON.parse(JSON.stringify(Filters.createTime.data)),
+          },
+        },
+        {
+          ...Filters.closeTime,
+          data: {
+            ...JSON.parse(JSON.stringify(Filters.closeTime.data)),
+          },
+        },
+
       ]}
       customFilter={true}
     ></IssueGrid>

--- a/website/src/pages/all.js
+++ b/website/src/pages/all.js
@@ -35,6 +35,8 @@ function Table() {
     Columns.number,
     Columns.title,
     Columns.state,
+    Columns.createdTime,
+    Columns.closedTime,
     Columns.pr,
     Columns.type,
     Columns.severity,


### PR DESCRIPTION
Issue Number: close #97 
- "All Issues"页面增加create time 和stop time
   -  因为现在字段较多，新增的两个字段默认隐藏，需要点击"COLUMNS"显示。后续周会中讨论使用频率看是否放开隐藏
       - （后续保存筛选项时考虑把列信息也进行保存
   - 在右上角Filters中增加Create Time和Close Time筛选，目前由于开发成本问题只提供"from"(time)筛选条件，有需要的话后续改造成同时可选择 from time和end time.
       - 如果sprint度量有需要统计信息，设计支持方案
 - 效果
 
<img width="1412" alt="image" src="https://user-images.githubusercontent.com/11363886/169200365-d7d7db5f-5343-4676-98f3-160ccfb3a480.png">
<img width="962" alt="image" src="https://user-images.githubusercontent.com/11363886/169200409-8559a18a-f1fc-49cc-bba8-848ddd519be8.png">
