### PR TITLE
fix: Only update one variable while there is an update on Version Triage Plane

### DIFF
--- a/internal/controller/version_triage_info.go
+++ b/internal/controller/version_triage_info.go
@@ -13,14 +13,14 @@ import (
 
 func CreateOrUpdateVersionTriage(c *gin.Context) {
 	// Params
-	versionTriage := entity.VersionTriage{}
-	if err := c.ShouldBindWith(&versionTriage, binding.JSON); err != nil {
+	versionTriageModifyOption := entity.VersionTriageModifyOption{}
+	if err := c.ShouldBindWith(&versionTriageModifyOption, binding.JSON); err != nil {
 		c.Error(err)
 		return
 	}
 
 	// Action
-	versionTriageInfo, err := service.CreateOrUpdateVersionTriageInfo(&versionTriage)
+	versionTriageInfo, err := service.CreateOrUpdateVersionTriageInfo(&versionTriageModifyOption.VersionTriage, versionTriageModifyOption.UpdatedVars...)
 	if nil != err {
 		c.Error(err)
 		return

--- a/internal/entity/version_triage.go
+++ b/internal/entity/version_triage.go
@@ -18,6 +18,7 @@ type VersionTriage struct {
 	DueTime             *time.Time                `json:"due_time,omitempty"`
 	Comment             string                    `json:"comment,omitempty"`
 	ChangedItem         VersionTriageChangedItem  `json:"changed_item,omitempty"`
+	UpdatedVars         []VersionTriageUpdatedVar `json:"updated_vars,omitempty" gorm:"-"`
 }
 
 // Enum type
@@ -59,6 +60,16 @@ const (
 	VersionTriageChangedItemBehavior       = VersionTriageChangedItem("behavior")
 	VersionTriageChangedItemNone           = VersionTriageChangedItem("none")
 	VersionTriageChangedItemUnKnown        = VersionTriageChangedItem("unknown")
+)
+
+type VersionTriageUpdatedVar string
+
+const (
+	VersionTriageUpdatedVarTriageOwner  = VersionTriageUpdatedVar("triage_owner")
+	VersionTriageUpdatedVarTriageResult = VersionTriageUpdatedVar("triage_result")
+	VersionTriageUpdatedVarBlockRelease = VersionTriageUpdatedVar("block_version_release")
+	VersionTriageUpdatedVarDueTime      = VersionTriageUpdatedVar("due_time")
+	VersionTriageUpdatedVarComment      = VersionTriageUpdatedVar("comment")
 )
 
 // List Option

--- a/internal/entity/version_triage.go
+++ b/internal/entity/version_triage.go
@@ -18,7 +18,6 @@ type VersionTriage struct {
 	DueTime             *time.Time                `json:"due_time,omitempty"`
 	Comment             string                    `json:"comment,omitempty"`
 	ChangedItem         VersionTriageChangedItem  `json:"changed_item,omitempty"`
-	UpdatedVars         []VersionTriageUpdatedVar `json:"updated_vars,omitempty" gorm:"-"`
 }
 
 // Enum type
@@ -83,6 +82,12 @@ type VersionTriageOption struct {
 	VersionNameList []string `json:"version_name_list,omitempty" form:"version_name_list" uri:"version_name_list"`
 
 	ListOption
+}
+
+type VersionTriageModifyOption struct {
+	VersionTriage
+
+	UpdatedVars []VersionTriageUpdatedVar `json:"updated_vars,omitempty"`
 }
 
 // DB-Table

--- a/internal/repository/version_triage.go
+++ b/internal/repository/version_triage.go
@@ -61,7 +61,7 @@ func UpdateVersionTriage(versionTriage *entity.VersionTriage) error {
 	return nil
 }
 
-func CreateOrUpdateVersionTriage(versionTriage *entity.VersionTriage) error {
+func CreateOrUpdateVersionTriage(versionTriage *entity.VersionTriage, updatedVars ...entity.VersionTriageUpdatedVar) error {
 	// 存储
 	if versionTriage.CreateTime.IsZero() {
 		versionTriage.CreateTime = time.Now()
@@ -70,7 +70,7 @@ func CreateOrUpdateVersionTriage(versionTriage *entity.VersionTriage) error {
 		versionTriage.UpdateTime = time.Now()
 	}
 	if err := database.DBConn.DB.Clauses(clause.OnConflict{
-		DoUpdates: clause.AssignmentColumns(composeUpdatedVars(*versionTriage)),
+		DoUpdates: clause.AssignmentColumns(composeUpdatedVars(updatedVars...)),
 	}).Create(&versionTriage).Error; err != nil {
 		return errors.Wrap(err, fmt.Sprintf("create or update version triage: %+v failed", versionTriage))
 	}
@@ -126,13 +126,13 @@ func VersionTriageLimit(option *entity.VersionTriageOption) string {
 	return sql
 }
 
-func composeUpdatedVars(versionTriage entity.VersionTriage) []string {
-	if len(versionTriage.UpdatedVars) == 0 {
+func composeUpdatedVars(updatedVars ...entity.VersionTriageUpdatedVar) []string {
+	if len(updatedVars) == 0 {
 		return []string{"update_time", "triage_owner", "triage_result", "block_version_release", "due_time", "comment"}
 	}
 
 	vars := []string{"update_time"}
-	for _, v := range versionTriage.UpdatedVars {
+	for _, v := range updatedVars {
 		if string(v) == "update_time" {
 			continue
 		}

--- a/internal/repository/version_triage.go
+++ b/internal/repository/version_triage.go
@@ -70,7 +70,7 @@ func CreateOrUpdateVersionTriage(versionTriage *entity.VersionTriage) error {
 		versionTriage.UpdateTime = time.Now()
 	}
 	if err := database.DBConn.DB.Clauses(clause.OnConflict{
-		DoUpdates: clause.AssignmentColumns([]string{"update_time", "triage_owner", "triage_result", "block_version_release", "due_time", "comment"}),
+		DoUpdates: clause.AssignmentColumns(composeUpdatedVars(*versionTriage)),
 	}).Create(&versionTriage).Error; err != nil {
 		return errors.Wrap(err, fmt.Sprintf("create or update version triage: %+v failed", versionTriage))
 	}
@@ -124,4 +124,19 @@ func VersionTriageLimit(option *entity.VersionTriageOption) string {
 	}
 
 	return sql
+}
+
+func composeUpdatedVars(versionTriage entity.VersionTriage) []string {
+	if len(versionTriage.UpdatedVars) == 0 {
+		return []string{"update_time", "triage_owner", "triage_result", "block_version_release", "due_time", "comment"}
+	}
+
+	vars := []string{"update_time"}
+	for _, v := range versionTriage.UpdatedVars {
+		if string(v) == "update_time" {
+			continue
+		}
+		vars = append(vars, string(v))
+	}
+	return vars
 }

--- a/internal/service/version_triage_info.go
+++ b/internal/service/version_triage_info.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateOrUpdateVersionTriageInfo(versionTriage *entity.VersionTriage) (*dto.VersionTriageInfo, error) {
+func CreateOrUpdateVersionTriageInfo(versionTriage *entity.VersionTriage, updatedVars ...entity.VersionTriageUpdatedVar) (*dto.VersionTriageInfo, error) {
 	// find version
 	releaseVersion, err := SelectReleaseVersionActive(versionTriage.VersionName)
 	if err != nil {
@@ -44,15 +44,15 @@ func CreateOrUpdateVersionTriageInfo(versionTriage *entity.VersionTriage) (*dto.
 	var isAccept bool = versionTriage.TriageResult == entity.VersionTriageResultAccept
 	if isFrozen && isAccept {
 		versionTriage.TriageResult = entity.VersionTriageResultAcceptFrozen
-		versionTriage.UpdatedVars = append(versionTriage.UpdatedVars, entity.VersionTriageUpdatedVarTriageResult)
+		updatedVars = append(updatedVars, entity.VersionTriageUpdatedVarTriageResult)
 	}
 
 	// 当issue为critical，且数据库中没有数据或BlockVersionRelease字段为空时，设置默认值为Block
 	if issueRelationInfo.Issue.SeverityLabel == git.SeverityCriticalLabel && (len(*storedVersionTriage) == 0 || (*storedVersionTriage)[0].BlockVersionRelease == "") {
 		versionTriage.BlockVersionRelease = entity.BlockVersionReleaseResultBlock
-		versionTriage.UpdatedVars = append(versionTriage.UpdatedVars, entity.VersionTriageUpdatedVarBlockRelease)
+		updatedVars = append(updatedVars, entity.VersionTriageUpdatedVarBlockRelease)
 	}
-	if err := repository.CreateOrUpdateVersionTriage(versionTriage); err != nil {
+	if err := repository.CreateOrUpdateVersionTriage(versionTriage, updatedVars...); err != nil {
 		return nil, err
 	}
 

--- a/website/src/components/issues/renderer/PickSelect.js
+++ b/website/src/components/issues/renderer/PickSelect.js
@@ -23,7 +23,8 @@ export default function PickSelect({
     mutation.mutate({
       issue_id: id,
       version_name: version,
-      triage_result: mapPickStatusToBackend(event.target.value)
+      triage_result: mapPickStatusToBackend(event.target.value),
+      updated_vars: ["triage_result"]
     });
     onChange(event.target.value);
     setAffects(event.target.value);


### PR DESCRIPTION
Issue Number: #101 
解决Version Triage页面修改字段会相互覆盖的问题
- 给VersionTriage添加判断条件UpdatedVars标识当次变更涉及的字段
- 当该triage记录是初次变更时，原有逻辑不受影响
- 当该triage记录不是初次变更时
    - 若不设置该字段，则原有逻辑不受影响
    - 若设置了该字段，紧在该字段中的变量会更新
    
实现效果如下 
![image](https://user-images.githubusercontent.com/11363886/169308069-6f4df06e-1b4b-4b48-b855-0155b85cd05d.png)
