### PR TITLE
+: make Release Block editable

### DIFF
--- a/website/src/components/issues/GridColumns.js
+++ b/website/src/components/issues/GridColumns.js
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { renderComment } from "./renderer/Comment";
 import { renderChanged } from "./renderer/ChangedItem";
 import { renderDateTime } from './renderer/Time'
+import { renderBlockRelease } from "./renderer/BlockRelease";
 
 const id = {
   field: "id",
@@ -144,6 +145,7 @@ const releaseBlock = {
   field: "release_block",
   headerName: "Release Blocked",
   valueGetter: (params) => params.row.version_triage.block_version_release,
+  renderCell: renderBlockRelease 
 };
 
 const comment = {

--- a/website/src/components/issues/renderer/BlockRelease.js
+++ b/website/src/components/issues/renderer/BlockRelease.js
@@ -1,0 +1,39 @@
+import { MenuItem, Select } from "@mui/material";
+import { useState } from "react";
+import { useMutation } from "react-query";
+import FormControl from "@mui/material/FormControl";
+import * as axios from "axios";
+import { url } from "../../../utils";
+
+const BlockReleaseSelect = ({ row }) => {
+  const [blocked, setBlocked] = useState(
+    row.version_triage.block_version_release || "-"
+  );
+  const mutation = useMutation(async (blocked) => {
+    await axios.patch(url("version_triage"), {
+      ...row.version_triage,
+      block_version_release: blocked,
+    });
+  });
+
+  return (
+    <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }}>
+    <Select
+      value={blocked}
+      onChange={(e) => {
+        mutation.mutate(e.target.value);
+        setBlocked(e.target.value);
+        row.version_triage.block_version_release = e.target.value;
+      }}
+    >
+      <MenuItem value="-" disabled={true}>-</MenuItem>
+      <MenuItem value="Block">Block</MenuItem>
+      <MenuItem value="None Block">None Block</MenuItem>
+    </Select>
+    </FormControl>
+  );
+};
+
+export function renderBlockRelease({ row }) {
+  return <BlockReleaseSelect row={row} />;
+}


### PR DESCRIPTION
Issue Number: close #103 
使Release Block按钮可编辑
- 非critical默认为-，编辑后不可再设置为 - 
效果如下
![image](https://user-images.githubusercontent.com/11363886/169324707-17af3035-7787-4bec-834d-b07152524be6.png)
