### PR TITLE
Auto refresh the pr label if the related issue is already approved

### DIFF
--- a/commons/git/pullrequest_parser.go
+++ b/commons/git/pullrequest_parser.go
@@ -1,0 +1,174 @@
+package git
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	issueNumberBlockRegexpTemplate = "(?i)%s?\\s*%s(?P<issue_number>[1-9]\\d*)"
+
+	associatePrefixRegexp           = "(?P<associate_prefix>ref|close[sd]?|resolve[sd]?|fix(e[sd])?)"
+	orgRegexp                       = "[a-zA-Z0-9][a-zA-Z0-9-]{0,38}"
+	repoRegexp                      = "[a-zA-Z0-9-_]{1,100}"
+	issueNumberPrefixRegexpTemplate = "(?P<issue_number_prefix>(https|http)://github\\.com/%s/%s/issues/|%s/%s#|#)"
+	linkPrefixRegexpTemplate        = "(https|http)://github\\.com/(?P<org>%s)/(?P<repo>%s)/issues/"
+	fullPrefixRegexpTemplate        = "(?P<org>%s)/(?P<repo>%s)#"
+	shortPrefix                     = "#"
+
+	associatePrefixGroupName   = "associate_prefix"
+	issueNumberPrefixGroupName = "issue_number_prefix"
+	issueNumberGroupName       = "issue_number"
+	orgGroupName               = "org"
+	repoGroupName              = "repo"
+)
+
+type IssueNumberData struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+var (
+	issueNumberPrefixRegexp = fmt.Sprintf(issueNumberPrefixRegexpTemplate, orgRegexp, repoRegexp, orgRegexp, repoRegexp)
+	linkPrefixRegexp        = fmt.Sprintf(linkPrefixRegexpTemplate, orgRegexp, repoRegexp)
+	fullPrefixRegexp        = fmt.Sprintf(fullPrefixRegexpTemplate, orgRegexp, repoRegexp)
+
+	pingcapIssueRefBlockRegexp = "(?im)Issue Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*((https|http)://github\\.com/" + orgRegexp + "/" + repoRegexp + "/issues/|" + orgRegexp + "/" + repoRegexp + "#|#)(?P<issue_number>[1-9]\\d*))+"
+)
+
+func ParseIssueNumber(content, currOwner, currRepo string) ([]IssueNumberData, error) {
+	issueNumberBlockRegexp := fmt.Sprintf(issueNumberBlockRegexpTemplate, associatePrefixRegexp, issueNumberPrefixRegexp)
+	pingcapIssueRefBlock, err := composeIssueBlocks(content, pingcapIssueRefBlockRegexp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	compile, err := regexp.Compile(issueNumberBlockRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	allMatches := compile.FindAllStringSubmatch(pingcapIssueRefBlock, -1)
+	groupNames := compile.SubexpNames()
+
+	issueNumberDatas := make([]IssueNumberData, 0)
+
+	for _, matches := range allMatches {
+		issueNumberPrefix := ""
+		issueNumber := 0
+		for i, groupName := range groupNames {
+			switch groupName {
+			case issueNumberPrefixGroupName:
+				issueNumberPrefix = strings.ToLower(strings.TrimSpace(matches[i]))
+			case issueNumberGroupName:
+				issueNumber, err = strconv.Atoi(strings.TrimSpace(matches[i]))
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if b, org, repo, err := isLinkPrefix(issueNumberPrefix); b && err == nil {
+			issueNumberDatas = append(issueNumberDatas, IssueNumberData{Owner: org, Repo: repo, Number: issueNumber})
+		} else if b, org, repo, err := isFullPrefix(issueNumberPrefix); b && err == nil {
+			issueNumberDatas = append(issueNumberDatas, IssueNumberData{Owner: org, Repo: repo, Number: issueNumber})
+		} else if isShortPrefix(issueNumberPrefix) {
+			issueNumberDatas = append(issueNumberDatas, IssueNumberData{Owner: currOwner, Repo: currRepo, Number: issueNumber})
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	return issueNumberDatas, nil
+
+}
+
+func composeIssueBlocks(content, issueRegexp string) (string, error) {
+
+	compile, err := regexp.Compile(issueRegexp)
+
+	if err != nil {
+		return "", err
+	}
+
+	allMatches := compile.FindAllString(content, -1)
+
+	matchedStrings := make([]string, 0)
+
+	for _, matche := range allMatches {
+		matchedStrings = append(matchedStrings, strings.ToLower(strings.TrimSpace(matche)))
+	}
+
+	return strings.Join(matchedStrings, " "), nil
+}
+
+// isLinkPrefix used to determine whether the prefix style of the issue number is link prefix,
+// for example: https://github/com/pingcap/tidb/issues/123.
+func isLinkPrefix(prefix string) (bool, string, string, error) {
+	compile, err := regexp.Compile(linkPrefixRegexp)
+	if err != nil {
+		return false, "", "", nil
+	}
+
+	matches := compile.FindStringSubmatch(prefix)
+	groupNames := compile.SubexpNames()
+
+	if matches == nil {
+		return false, "", "", nil
+	}
+
+	org := ""
+	repo := ""
+	for i, match := range matches {
+		groupName := groupNames[i]
+		if groupName == orgGroupName {
+			org = match
+		} else if groupName == repoGroupName {
+			repo = match
+		}
+	}
+
+	return true, org, repo, nil
+}
+
+// isFullPrefix used to determine whether the prefix style of the issue number is full prefix,
+// for example: pingcap/tidb#123.
+func isFullPrefix(prefix string) (bool, string, string, error) {
+	compile, err := regexp.Compile(fullPrefixRegexp)
+	if err != nil {
+		return false, "", "", err
+	}
+
+	matches := compile.FindStringSubmatch(prefix)
+	groupNames := compile.SubexpNames()
+
+	if matches == nil {
+		return false, "", "", nil
+	}
+
+	org := ""
+	repo := ""
+	for i, match := range matches {
+		groupName := groupNames[i]
+		if groupName == orgGroupName {
+			org = match
+		} else if groupName == repoGroupName {
+			repo = match
+		}
+	}
+
+	return true, org, repo, nil
+}
+
+// isShortPrefix used to determine whether the prefix style of the issue number is short prefix,
+// for example: #123.
+func isShortPrefix(prefix string) bool {
+	return prefix == shortPrefix
+}

--- a/commons/git/pullrequest_parser_test.go
+++ b/commons/git/pullrequest_parser_test.go
@@ -1,0 +1,47 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIssueNumber(t *testing.T) {
+
+	issueNumberDatas, err := ParseIssueNumber(shortIssueNumbers, "pingcap", "tidb")
+	assert.Equal(t, 1, len(issueNumberDatas))
+	assert.Equal(t, "pingcap", issueNumberDatas[0].Owner)
+	assert.Equal(t, "tidb", issueNumberDatas[0].Repo)
+	assert.Equal(t, 11111, issueNumberDatas[0].Number)
+	assert.Equal(t, nil, err)
+
+	issueNumberDatas, err = ParseIssueNumber(fullIssueNumebrs, "", "")
+	assert.Equal(t, 1, len(issueNumberDatas))
+	assert.Equal(t, "pingcap", issueNumberDatas[0].Owner)
+	assert.Equal(t, "tidb", issueNumberDatas[0].Repo)
+	assert.Equal(t, 22222, issueNumberDatas[0].Number)
+	assert.Equal(t, nil, err)
+
+	issueNumberDatas, err = ParseIssueNumber(linkIssueNumbers, "", "")
+	assert.Equal(t, 1, len(issueNumberDatas))
+	assert.Equal(t, "pingcap", issueNumberDatas[0].Owner)
+	assert.Equal(t, "tidb", issueNumberDatas[0].Repo)
+	assert.Equal(t, 3333, issueNumberDatas[0].Number)
+	assert.Equal(t, nil, err)
+
+	issueNumberDatas, err = ParseIssueNumber(multipleIssueNumbers, "pingcap", "tidb")
+	assert.Equal(t, 3, len(issueNumberDatas))
+	assert.Equal(t, "pingcap", issueNumberDatas[0].Owner)
+	assert.Equal(t, "tidb", issueNumberDatas[0].Repo)
+	assert.Equal(t, 1, issueNumberDatas[0].Number)
+	assert.Equal(t, nil, err)
+
+}
+
+const (
+	shortIssueNumbers = "xxxxx Issue Number: close #11111"
+	fullIssueNumebrs  = "xxxxx Issue Number: close pingcap/tidb#22222"
+	linkIssueNumbers  = "xxxxx Issue Number: close https://github.com/pingcap/tidb/issues/3333"
+
+	multipleIssueNumbers = "xxxxx Issue Number: close #1, close pingcap/tidb#2, close https://github.com/pingcap/tidb/issues/3"
+)

--- a/internal/controller/webhook_github.go
+++ b/internal/controller/webhook_github.go
@@ -63,6 +63,9 @@ func GithubWebhookHandler(c *gin.Context) {
 		}
 		baseBranch := event.PullRequest.Base.Ref
 		if baseBranch != nil && strings.HasPrefix(*baseBranch, git.ReleaseBranchPrefix) {
+			// If the auto refesh operion failed ,just let it go.
+			service.AutoRefreshPrApprovedLabel(event.PullRequest)
+
 			err := service.WebHookRefreshPullRequestRefIssue(event.PullRequest)
 			if err != nil {
 				c.Error(err)

--- a/internal/entity/pull_request.go
+++ b/internal/entity/pull_request.go
@@ -42,6 +42,7 @@ type PullRequest struct {
 	Labels             *[]github.Label `json:"labels,omitempty" gorm:"-"`
 	Assignees          *[]github.User  `json:"assignees,omitempty" gorm:"-"`
 	RequestedReviewers *[]github.User  `json:"requested_reviewers,omitempty" gorm:"-"`
+	Body               string          `json:"body,omitempty"`
 }
 
 // List Option
@@ -131,6 +132,7 @@ func ComposePullRequestFromV3(pullRequest *github.PullRequest) *PullRequest {
 		Labels:             labels,
 		Assignees:          assignees,
 		RequestedReviewers: requestedReviewers,
+		Body:               *pullRequest.Body,
 	}
 }
 

--- a/internal/service/webhook_pull_request_test.go
+++ b/internal/service/webhook_pull_request_test.go
@@ -94,3 +94,61 @@ func TestWebHookRefreshPullRequestRefIssue(t *testing.T) {
 	err := WebHookRefreshPullRequestRefIssue(pr)
 	assert.Equal(t, true, err == nil)
 }
+
+func TestCheckTriageStatus(t *testing.T) {
+	t.Skip()
+	database.Connect(generateConfig())
+	versions := []entity.ReleaseVersion{
+		{
+			Name: "6.1.0",
+		}}
+	issues := []entity.Issue{
+		{
+			IssueID: "I_kwDOAy145M5JhkMT",
+		}}
+
+	hasFrozen, allApproved, err := checkTriageStatus(versions, issues)
+	assert.Equal(t, false, hasFrozen)
+	assert.Equal(t, true, allApproved)
+	assert.Equal(t, nil, err)
+
+	versions = []entity.ReleaseVersion{
+		{
+			Name: "6.1.0",
+		}}
+	issues = []entity.Issue{
+		{
+			IssueID: "I_kwDOAuklds5DLJQq",
+		}}
+
+	hasFrozen, allApproved, err = checkTriageStatus(versions, issues)
+	assert.Equal(t, false, hasFrozen)
+	assert.Equal(t, false, allApproved)
+	assert.Equal(t, nil, err)
+
+	versions = []entity.ReleaseVersion{
+		{
+			Name: "6.1.0",
+		}}
+	issues = []entity.Issue{
+		{
+			IssueID: "mock one",
+		}}
+
+	hasFrozen, allApproved, err = checkTriageStatus(versions, issues)
+	assert.Equal(t, false, hasFrozen)
+	assert.Equal(t, false, allApproved)
+	assert.Equal(t, nil, err)
+
+}
+
+func TestAutoRefreshPrApprovedLabel(t *testing.T) {
+	t.Skip()
+	// init
+	git.Connect(git.TestToken)
+	git.ConnectV4(git.TestToken)
+	database.Connect(generateConfig())
+
+	pr, _, _ := git.Client.GetPullRequestByNumber("pingcap", "tiflash", 4970)
+	AutoRefreshPrApprovedLabel(pr)
+}


### PR DESCRIPTION
Issue Number: close #110 
1. Get the related issues by the pr body.
- ref
    - [将拉取请求链接到议题 \- GitHub Docs](https://docs.github.com/cn/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
    - [test\-infra/issue\_number\.go at 3c82893fc2d9f28215d2c05cfb47a4ee4cec48eb · ti\-community\-infra/test\-infra](https://github.com/ti-community-infra/test-infra/blob/3c82893fc2d9f28215d2c05cfb47a4ee4cec48eb/prow/github/issue_number.go#L59)
2. Get the release version from the baseBranch of the pr 
3. Query the triage history using the issues and the release versions from 1. and 2.
4. if all related triages have been labeled approved, automatically label the pr to be approved.

Some key steps of the changes have been tested.