### PR TITLE
Fix Issue: Released triages have wrong value.

### DIFF
--- a/internal/service/version_triage_info.go
+++ b/internal/service/version_triage_info.go
@@ -119,7 +119,7 @@ func SelectVersionTriageInfo(query *dto.VersionTriageInfoQuery) (*dto.VersionTri
 
 	// compose
 	var versionTriages []entity.VersionTriage
-	if releaseVersion.Status == entity.ReleaseVersionStatusUpcoming {
+	if releaseVersion.Status == entity.ReleaseVersionStatusUpcoming || releaseVersion.Status == entity.ReleaseVersionStatusFrozen {
 		versionTriages, err = ComposeVersionTriageUpcomingList(query.Version)
 		if err != nil {
 			return nil, nil, err

--- a/website/src/components/issues/renderer/mapper.js
+++ b/website/src/components/issues/renderer/mapper.js
@@ -15,7 +15,8 @@ export function mapPickStatusToFrontend(pick) {
         unknown: "unknown",
         later: "later",
         "won't fix": "won't fix",
-        "accept(frozen)": "approved(frozen)"
+        "accept(frozen)": "approved(frozen)",
+        "released": "released"
     }[pick]
     return pick
 }


### PR DESCRIPTION
Issue Number: close #117 
The reason is that there is none related logic to deal with released status of version triage.