### PR TITLE
Fix the automation logic of triage status while version released & Add frozen version to all issues plane.

### DIFF
--- a/internal/service/release_version.go
+++ b/internal/service/release_version.go
@@ -77,6 +77,16 @@ func SelectReleaseVersionMaintained() (*[]string, error) {
 	if nil != err {
 		return nil, err
 	}
+
+	option = &entity.ReleaseVersionOption{
+		Status: entity.ReleaseVersionStatusFrozen,
+	}
+	frozenVersions, err := repository.SelectReleaseVersion(option)
+	if nil != err {
+		return nil, err
+	}
+	*versions = append(*versions, *frozenVersions...)
+
 	set := mapset.NewSet()
 	for _, version := range *versions {
 		set.Add(ComposeVersionMinorName(&version))

--- a/internal/service/version_triage_helper.go
+++ b/internal/service/version_triage_helper.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"tirelease/internal/entity"
+	"tirelease/internal/repository"
+)
+
+func getTriageAndPRsMap(triages []entity.VersionTriage, version string) (map[entity.VersionTriage][]entity.PullRequest, error) {
+	// Get all related issueIds
+	issueIDs := extractIssueIDsFromTriage(triages)
+
+	issuePrRelations, err := getIssuePrRelation(issueIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	pullrequests, err := getRelatedPullRequests(issuePrRelations)
+	if err != nil {
+		return nil, err
+	}
+
+	releaseVersion, err := repository.SelectReleaseVersionLatest(
+		&entity.ReleaseVersionOption{
+			Name: version,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	pullrequests = filterPRsByBranch(pullrequests, ComposeVersionBranch(releaseVersion))
+
+	return mapVersionTriagesWithPrs(triages, issuePrRelations, pullrequests), nil
+}
+
+func extractIssueIDsFromTriage(triages []entity.VersionTriage) []string {
+	issueIDs := make([]string, 0)
+	for _, triage := range triages {
+		issueIDs = append(issueIDs, triage.IssueID)
+	}
+	return issueIDs
+}
+
+func filterPRsByBranch(prs []entity.PullRequest, branch string) []entity.PullRequest {
+	var filteredPRs []entity.PullRequest
+	for _, pr := range prs {
+		if pr.BaseBranch == branch {
+			filteredPRs = append(filteredPRs, pr)
+		}
+	}
+	return filteredPRs
+}
+
+// Notes: the version of pullrequests in the params is the same with the triage
+// TODO: refactor the model of version triage to contain the related info.
+func mapVersionTriagesWithPrs(triages []entity.VersionTriage, issuePrRelation []entity.IssuePrRelation, prs []entity.PullRequest) map[entity.VersionTriage][]entity.PullRequest {
+	triagePRMap := make(map[entity.VersionTriage][]entity.PullRequest)
+	for _, triage := range triages {
+		for _, relation := range issuePrRelation {
+			if triage.IssueID != relation.IssueID {
+				continue
+			}
+
+			for _, pr := range prs {
+				if relation.PullRequestID == pr.PullRequestID {
+					triagePRMap[triage] = append(triagePRMap[triage], pr)
+				}
+			}
+		}
+	}
+	return triagePRMap
+}

--- a/internal/service/webhook_issue_test.go
+++ b/internal/service/webhook_issue_test.go
@@ -145,3 +145,11 @@ func TestExportHistoryVersionTriageWithDatabase(t *testing.T) {
 	err := ExportHistoryVersionTriageWithDatabase(option)
 	assert.Equal(t, true, err == nil)
 }
+
+func TestInheritVersionTriage(t *testing.T) {
+	t.Skip()
+
+	database.Connect(generateConfig())
+
+	InheritVersionTriage("5.4.2", "5.4.3")
+}

--- a/internal/service/webhook_pull_request_test.go
+++ b/internal/service/webhook_pull_request_test.go
@@ -161,7 +161,7 @@ func TestRefreshPrIssueRefByPrContent(t *testing.T) {
 	git.ConnectV4(git.TestToken)
 	database.Connect(generateConfig())
 
-	prV4, err := git.ClientV4.GetPullRequestByID(git.TestPullRequestNodeID4)
+	prV4, err := git.ClientV4.GetPullRequestByID(git.TestPullRequestNodeID3)
 	assert.Equal(t, nil, err)
 	refreshPrIssueRefByPrContent(prV4)
 


### PR DESCRIPTION
Issue Number: close #142 #141 
Fix the automation logic of triage status while version released
- the approved issues will be made released only when they are finished.
- the later issues will remain later
