### PR TITLE
feature: add release note parsing.

### DIFF
--- a/commons/git/pullrequest_parser.go
+++ b/commons/git/pullrequest_parser.go
@@ -172,3 +172,40 @@ func isFullPrefix(prefix string) (bool, string, string, error) {
 func isShortPrefix(prefix string) bool {
 	return prefix == shortPrefix
 }
+
+var (
+	pingcapReleaseNoteRegex = "(?s)(?:Release note\\*\\*:\\s*(?:<!--[^<>]*-->\\s*)?```(?:release-note)?|```release-note)(?P<release_note>.+?)```"
+	releaseNoteGroupName    = "release_note"
+)
+
+type ReleaseNoteData struct {
+	IsReleaseNoteConfirmed bool
+	ReleaseNote            string
+}
+
+func ParseReleaseNote(content string) (ReleaseNoteData, error) {
+
+	compile, err := regexp.Compile(pingcapReleaseNoteRegex)
+	if err != nil {
+		return ReleaseNoteData{false, ""}, err
+	}
+
+	allMatches := compile.FindAllStringSubmatch(content, -1)
+	groupNames := compile.SubexpNames()
+	releaseNote := ""
+	hasReleaseNote := false
+
+	for _, matches := range allMatches {
+		for i, groupName := range groupNames {
+			switch groupName {
+			case releaseNoteGroupName:
+				releaseNote = strings.TrimSpace(matches[i])
+				hasReleaseNote = true
+			}
+		}
+
+	}
+
+	return ReleaseNoteData{hasReleaseNote, releaseNote}, nil
+
+}

--- a/commons/git/pullrequest_parser_test.go
+++ b/commons/git/pullrequest_parser_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	shortIssueNumbers = "xxxxx Issue Number: close #11111"
+	fullIssueNumebrs  = "xxxxx Issue Number: close pingcap/tidb#22222"
+	linkIssueNumbers  = "xxxxx Issue Number: close https://github.com/pingcap/tidb/issues/3333"
+
+	multipleIssueNumbers = "xxxxx Issue Number: close #1, close pingcap/tidb#2, close https://github.com/pingcap/tidb/issues/3"
+)
+
 func TestParseIssueNumber(t *testing.T) {
 
 	issueNumberDatas, err := ParseIssueNumber(shortIssueNumbers, "pingcap", "tidb")
@@ -39,9 +47,11 @@ func TestParseIssueNumber(t *testing.T) {
 }
 
 const (
-	shortIssueNumbers = "xxxxx Issue Number: close #11111"
-	fullIssueNumebrs  = "xxxxx Issue Number: close pingcap/tidb#22222"
-	linkIssueNumbers  = "xxxxx Issue Number: close https://github.com/pingcap/tidb/issues/3333"
-
-	multipleIssueNumbers = "xxxxx Issue Number: close #1, close pingcap/tidb#2, close https://github.com/pingcap/tidb/issues/3"
+	releaseNote = "<!--\r\n\r\nThank you for contributing to TiDB!\r\n\r\nPR Title Format:\r\n1. pkg [, pkg2, pkg3]: what's changed\r\n2. *: what's changed\r\n\r\n-->\r\n\r\n### What problem does this PR solve?\r\n<!--\r\n\r\nPlease create an issue first to describe the problem.\r\n\r\nThere MUST be one line starting with \"Issue Number:  \" and \r\nlinking the relevant issues via the \"close\" or \"ref\".\r\n\r\nFor more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.\r\n\r\n-->\r\n\r\nIssue Number: close #35880\r\n\r\nProblem Summary:\r\n\r\n### What is changed and how it works?\r\nsee issue description\r\n\r\n### Check List\r\n\r\nTests <!-- At least one of them must be included. -->\r\n\r\n- [x] Unit test\r\n- [ ] Integration test\r\n- [ ] Manual test (add detailed scripts or steps below)\r\n- [ ] No code\r\n\r\nSide effects\r\n\r\n- [ ] Performance regression: Consumes more CPU\r\n- [ ] Performance regression: Consumes more Memory\r\n- [ ] Breaking backward compatibility\r\n\r\nDocumentation\r\n\r\n- [ ] Affects user behaviors\r\n- [ ] Contains syntax changes\r\n- [ ] Contains variable changes\r\n- [ ] Contains experimental features\r\n- [ ] Changes MySQL compatibility\r\n\r\n### Release note\r\n\r\n<!-- compatibility change, improvement, bugfix, and new feature need a release note -->\r\n\r\nPlease refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.\r\n\r\n```release-note\r\nfix connect to tidb when using ipv6 host\r\n```\r\n"
 )
+
+func TestParseReleaseNote(t *testing.T) {
+	releaseNote, err := ParseReleaseNote(releaseNote)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "fix connect to tidb when using ipv6 host", releaseNote.ReleaseNote)
+}

--- a/internal/entity/pull_request.go
+++ b/internal/entity/pull_request.go
@@ -37,6 +37,8 @@ type PullRequest struct {
 	LabelsString             string `json:"labels_string,omitempty"`
 	AssigneesString          string `json:"assignees_string,omitempty"`
 	RequestedReviewersString string `json:"requested_reviewers_string,omitempty"`
+	IsReleaseNoteConfirmed   bool   `json:"is_release_note_confirmed,omitempty"`
+	ReleaseNote              string `json:"releaseNote,omitempty"`
 
 	// OutPut-Serial
 	Labels             *[]github.Label `json:"labels,omitempty" gorm:"-"`

--- a/internal/service/git_event_consumer/base.go
+++ b/internal/service/git_event_consumer/base.go
@@ -1,0 +1,23 @@
+package gconsumer
+
+import "github.com/google/go-github/v41/github"
+
+type PREventConsumer interface {
+	Validate(event github.PullRequestEvent) bool
+	Consume(event github.PullRequestEvent) error
+}
+
+var pREventConsumer []PREventConsumer
+
+func GetPREventConsumers() []PREventConsumer {
+	if pREventConsumer == nil {
+		initPREventConsumerMap()
+	}
+
+	return pREventConsumer
+}
+
+func initPREventConsumerMap() {
+	pREventConsumer = make([]PREventConsumer, 0)
+	pREventConsumer = append(pREventConsumer, PrReleaseNoteConsumer{})
+}

--- a/internal/service/git_event_consumer/pr_release_note.go
+++ b/internal/service/git_event_consumer/pr_release_note.go
@@ -1,0 +1,44 @@
+package gconsumer
+
+import (
+	"tirelease/commons/git"
+	"tirelease/internal/entity"
+	"tirelease/internal/repository"
+
+	"github.com/google/go-github/v41/github"
+)
+
+type PrReleaseNoteConsumer struct {
+}
+
+const NONE_RELEASE_NOTE_LABEL = "release-note-none"
+
+// ref: [release\-note](https://book.prow.tidb.io/#/plugins/release-note)
+func (consumer PrReleaseNoteConsumer) Consume(event github.PullRequestEvent) error {
+	prEntity := entity.ComposePullRequestFromV3(event.PullRequest)
+	releaseNote, err := git.ParseReleaseNote(prEntity.Body)
+
+	if err != nil || !releaseNote.IsReleaseNoteConfirmed {
+		labels := prEntity.Labels
+		for _, label := range *labels {
+			if *label.Name == NONE_RELEASE_NOTE_LABEL {
+				releaseNote.IsReleaseNoteConfirmed = true
+				releaseNote.ReleaseNote = "None"
+			}
+		}
+	}
+
+	if !releaseNote.IsReleaseNoteConfirmed {
+		return nil
+	}
+
+	prEntity.IsReleaseNoteConfirmed = releaseNote.IsReleaseNoteConfirmed
+	prEntity.ReleaseNote = releaseNote.ReleaseNote
+	err = repository.CreateOrUpdatePullRequest(prEntity)
+
+	return err
+}
+
+func (consumer PrReleaseNoteConsumer) Validate(event github.PullRequestEvent) bool {
+	return true
+}

--- a/website/src/layout/LoginListItem.js
+++ b/website/src/layout/LoginListItem.js
@@ -29,11 +29,11 @@ export default function LoginListItem() {
         <ListItem button onClick={onLogin}>
             <ListItemIcon>
                 {
-                    hasLogged ? <Avatar src={loginUser.git_avatar_url} sx={{width: "20px", height: "20px"}}/> : <GitHubIcon />
+                    hasLogged && loginUser !== undefined ? <Avatar src={loginUser.git_avatar_url} sx={{ width: "20px", height: "20px" }} /> : <GitHubIcon />
                 }
             </ListItemIcon>
             <ListItemText primary={
-                hasLogged ? loginUser.git_login : 'Login'
+                hasLogged && loginUser !== undefined ? loginUser.git_login : 'Login'
             } />
         </ListItem>
     );

--- a/website/src/layout/Orders.js
+++ b/website/src/layout/Orders.js
@@ -89,7 +89,7 @@ export const otherListItems = (
       </ListItemIcon>
       <ListItemText primary="Docs" />
     </ListItem>
-    <LoginListItem/>
+    {/* <LoginListItem/> */}
   </div>
 );
 


### PR DESCRIPTION
Issue Number: close #150 
- Add template of git event consumers according to **Observer design pattern**
  - Add release note parsing logic to the webhook controller templately, it'll be moved to isolated **notifier** later.
- Comment the **login entrance.**